### PR TITLE
feat: enhance task navigation with Today and Switch Child buttons

### DIFF
--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,6 +1,12 @@
 <div class="max-w-2xl mx-auto p-4">
   <header class="text-center mb-8">
     <h1 class="text-2xl font-bold mb-4">ChoreTracker</h1>
+    <div class="mb-4">
+      <span class="text-lg"><%= @child.name %></span>
+      <%= button_to "Switch Child", session_path, 
+          method: :delete,
+          class: "inline-block ml-4 px-4 py-1 border-2 border-black text-base font-semibold hover:bg-gray-100" %>
+    </div>
     <div class="flex items-center justify-center gap-4 mb-4">
       <%= link_to "←", tasks_path(date: @date - 1), 
           class: "text-2xl px-4 py-2" %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,7 +1,7 @@
 <div class="max-w-2xl mx-auto p-4">
   <header class="text-center mb-8">
     <h1 class="text-2xl font-bold mb-4">ChoreTracker</h1>
-    <div class="flex items-center justify-center gap-4">
+    <div class="flex items-center justify-center gap-4 mb-4">
       <%= link_to "←", tasks_path(date: @date - 1), 
           class: "text-2xl px-4 py-2" %>
       <h2 class="text-xl">
@@ -11,6 +11,12 @@
           class: "text-2xl px-4 py-2",
           style: (@date >= Date.current ? "visibility: hidden" : "") %>
     </div>
+    <% unless @is_today %>
+      <div>
+        <%= link_to "Today", tasks_path, 
+            class: "inline-block px-6 py-2 border-2 border-black text-lg font-semibold hover:bg-gray-100" %>
+      </div>
+    <% end %>
   </header>
   
   <% %w[morning afternoon evening].each do |time_period| %>

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -26,4 +26,20 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to new_session_path
     assert_nil session[:child_id]
   end
+
+  def test_destroy_from_tasks_page_flow
+    # Select a child and go to tasks
+    post session_path, params: { id: children(:eddie).id }
+    get tasks_path
+    assert_response :success
+
+    # Use the switch child button
+    delete session_path
+    assert_redirected_to new_session_path
+    follow_redirect!
+
+    # Should be back at child selection
+    assert_select "h1", "Who are you?"
+    assert_nil session[:child_id]
+  end
 end

--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -1,0 +1,58 @@
+require "test_helper"
+
+class TasksControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    # Select a child for tests that require child authentication
+    post session_path, params: { id: children(:eddie).id }
+  end
+
+  def test_index_shows_tasks_for_current_date
+    get tasks_path
+    assert_response :success
+    assert_select "h2", /#{Date.current.strftime("%A, %B %d")}/
+  end
+
+  def test_index_shows_tasks_for_specific_date
+    date = Date.current - 3.days
+    get tasks_path(date: date)
+    assert_response :success
+    assert_select "h2", /#{date.strftime("%A, %B %d")}/
+  end
+
+  def test_today_button_not_shown_on_current_date
+    get tasks_path
+    assert_response :success
+    assert_select "a", text: "Today", count: 0
+  end
+
+  def test_today_button_shown_on_past_date
+    get tasks_path(date: Date.current - 1.day)
+    assert_response :success
+    assert_select "a[href=?]", tasks_path, text: "Today"
+  end
+
+  def test_forward_navigation_hidden_on_current_date
+    get tasks_path
+    assert_response :success
+    # Check that the forward arrow has visibility: hidden style
+    assert_select "a", text: "→" do |elements|
+      assert elements.first["style"].include?("visibility: hidden")
+    end
+  end
+
+  def test_forward_navigation_visible_on_past_date
+    get tasks_path(date: Date.current - 1.day)
+    assert_response :success
+    # Check that the forward arrow does not have visibility: hidden style
+    assert_select "a", text: "→" do |elements|
+      assert_not elements.first["style"].include?("visibility: hidden")
+    end
+  end
+end
+
+class TasksControllerRedirectTest < ActionDispatch::IntegrationTest
+  def test_redirects_to_new_session_when_no_child_selected
+    get tasks_path
+    assert_redirected_to new_session_path
+  end
+end

--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -48,6 +48,21 @@ class TasksControllerTest < ActionDispatch::IntegrationTest
       assert_not elements.first["style"].include?("visibility: hidden")
     end
   end
+
+  def test_shows_current_child_name
+    get tasks_path
+    assert_response :success
+    assert_select "span", text: "Eddie"
+  end
+
+  def test_shows_switch_child_button
+    get tasks_path
+    assert_response :success
+    assert_select "form[action=?][method=?]", session_path, "post" do
+      assert_select "input[name=?][value=?]", "_method", "delete"
+      assert_select "button", text: "Switch Child"
+    end
+  end
 end
 
 class TasksControllerRedirectTest < ActionDispatch::IntegrationTest


### PR DESCRIPTION
## Summary
- Add "Today" button for quick navigation back to current date
- Add "Switch Child" button to easily change between children
- Display current child's name in task header

## Implementation Details

### Today Button
- Only appears when viewing past dates
- Provides one-click navigation back to current date
- Styled consistently with other UI elements

### Switch Child Feature
- Shows current child's name in the header
- "Switch Child" button uses proper RESTful design
- Calls `session#destroy` then redirects to `session#new`
- Uses `button_to` with DELETE method for proper HTTP semantics

## Test Coverage
- Added comprehensive tests for navigation behavior
- Tests verify Today button visibility logic
- Tests confirm Switch Child flow works end-to-end
- All 47 tests passing

## Related to
- Phase 2.3 in implementation plan
- Improves navigation UX as requested

🤖 Generated with [Claude Code](https://claude.ai/code)