### PR TITLE
Fix checkbox page reload issue with Turbo

### DIFF
--- a/app/views/tasks/_tasks_frame.html.erb
+++ b/app/views/tasks/_tasks_frame.html.erb
@@ -18,7 +18,7 @@
               <label class="flex items-center py-4 border-b border-muted cursor-pointer min-h-15 hover:bg-muted hover:-mx-4 hover:px-4 transition-all duration-150">
                 <input type="checkbox" 
                        <%= 'checked' if completion %>
-                       onchange="this.form.submit()"
+                       onchange="this.form.requestSubmit()"
                        class="mr-6 flex-shrink-0">
                 <span class="text-lg font-light flex-grow <%= 'line-through text-muted-foreground' if completion %>"><%= task.name.capitalize %></span>
               </label>


### PR DESCRIPTION
## Summary
- Fixed checkbox form submissions causing full page reloads and scroll position loss
- Changed `onchange` handler from `form.submit()` to `form.requestSubmit()` to enable proper Turbo interception

## Test plan
- [x] Navigate to tasks page with multiple tasks
- [x] Scroll down to tasks in the evening section
- [x] Check/uncheck a task checkbox
- [x] Verify the page updates without reloading and maintains scroll position
- [x] Verify task completion state is properly saved

🤖 Generated with [Claude Code](https://claude.ai/code)