### PR TITLE
feat: pass current viewing date to weekly review

### DIFF
--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -5,7 +5,7 @@
         <div class="flex justify-between items-center">
           <h1 class="text-xl font-semibold"><%= @child.name %>'s Tasks</h1>
           <div class="flex items-center gap-3">
-            <%= link_to "Weekly Review", review_path, class: "nav-button nav-button-primary" %>
+            <%= link_to "Weekly Review", review_path(week_start: date_param_string(@date)), class: "nav-button nav-button-primary" %>
             <%= button_to "Switch Child", session_path, method: :delete, class: "nav-button nav-button-secondary" %>
           </div>
         </div>
@@ -41,7 +41,7 @@
       <span class="text-lg font-medium"><%= @child.name %>'s Tasks</span>
     </div>
     <div class="flex items-center gap-2 md:gap-4">
-      <%= link_to "Weekly Review", review_path, 
+      <%= link_to "Weekly Review", review_path(week_start: date_param_string(@date)), 
           class: "btn px-3 md:px-4 py-2 text-sm min-h-11" %>
       <%= button_to "Switch Child", session_path, 
           method: :delete,


### PR DESCRIPTION
Updates Weekly Review links to pass the current viewing date as week_start parameter, allowing the review to show the appropriate week window based on the date being viewed in daily tasks rather than always showing the current week.

🤖 Generated with [Claude Code](https://claude.ai/code)